### PR TITLE
compatibility with Dashcore-node

### DIFF
--- a/dashcore-node/index.js
+++ b/dashcore-node/index.js
@@ -9,7 +9,7 @@ var InsightUI = function(options) {
   if (typeof options.apiPrefix !== 'undefined') {
     this.apiPrefix = options.apiPrefix;
   } else {
-    this.apiPrefix = 'insight-api';
+    this.apiPrefix = '@dashevo/insight-api';
   }
   if (typeof options.routePrefix !== 'undefined') {
     this.routePrefix = options.routePrefix;

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "dashcore"
   ],
   "dashcoreNode": "dashcore-node",
+  "main": "dashcore-node",
   "scripts": {
     "build": "bower install && grunt compile",
     "watch": "grunt",


### PR DESCRIPTION
full compatibility with Dashcore-node (@dashevo/insight-api path)
fix problem when starting Dashcore-node with insight-ui service:
Error: Cannot find module '@dashevo/insight-ui'
